### PR TITLE
Update `cgp` to v0.5.0-alpha and remove async `Send` bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,27 +100,19 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cgp"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28b6a4b8ff69cab423ad922c5e59aaf27147a91371ce07963773bba5f675e41"
 dependencies = [
- "cgp-async",
  "cgp-core",
  "cgp-extra",
 ]
 
 [[package]]
-name = "cgp-async"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
-dependencies = [
- "cgp-async-macro",
- "cgp-sync",
-]
-
-[[package]]
 name = "cgp-async-macro"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a7713af5cad60c611e11a4c6454c3419dec22534bbd95da16a3f30c891ce07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -129,15 +121,17 @@ dependencies = [
 
 [[package]]
 name = "cgp-component"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6df81a3b17476059494a0be43bda2842aaf222038f25575797476e34596b88"
 
 [[package]]
 name = "cgp-core"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb8b35de4b11901427e9e3a47119ff31c6e6019990713e09ae4b8095d9a1c495"
 dependencies = [
- "cgp-async",
+ "cgp-async-macro",
  "cgp-component",
  "cgp-error",
  "cgp-field",
@@ -147,8 +141,9 @@ dependencies = [
 
 [[package]]
 name = "cgp-dispatch"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a36ea06947a7d1c6e77375d512bd2bfef79170ea567e6948444cfd1d685132f"
 dependencies = [
  "cgp-core",
  "cgp-handler",
@@ -157,10 +152,10 @@ dependencies = [
 
 [[package]]
 name = "cgp-error"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbe241a385657e24ddd99f158248612044ec6a103d80f0081dbdc9e2ca6af1f"
 dependencies = [
- "cgp-async",
  "cgp-component",
  "cgp-macro",
  "cgp-type",
@@ -168,8 +163,9 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-anyhow"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0014b771bdf0b2e8ec4bac2540776a2d8a271f182e736ece6a227f876c533c3"
 dependencies = [
  "anyhow",
  "cgp-core",
@@ -177,21 +173,24 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-extra"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8005bea1b444df810719da13cda7ad280f06a44c17c47d981df8f0041eafd263"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-extra"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310841c4da3ae2529e585e846f1ad7cfceb17244aa153fa9f0503bcb902633c7"
 dependencies = [
  "cgp-core",
  "cgp-dispatch",
  "cgp-error-extra",
  "cgp-extra-macro",
+ "cgp-field-extra",
  "cgp-handler",
  "cgp-inner",
  "cgp-monad",
@@ -201,8 +200,9 @@ dependencies = [
 
 [[package]]
 name = "cgp-extra-macro"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa704255470c6fa0e0a1f84eba3233802322672e671bc0f47ffedb3dfadd48e"
 dependencies = [
  "cgp-extra-macro-lib",
  "syn",
@@ -210,8 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cgp-extra-macro-lib"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257f13b0a0e48ff9712bb85dd22f096b6a709ab9cdb2157fcb290fa5a86fb6a4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -220,26 +221,37 @@ dependencies = [
 
 [[package]]
 name = "cgp-field"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d116a8dbc4f3c67b13d4fca8e655bf7ae6fc1012fbe6d9f9850b96f6ccacf1e3"
 dependencies = [
  "cgp-component",
- "cgp-macro",
  "cgp-type",
 ]
 
 [[package]]
+name = "cgp-field-extra"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac2538e352defeb105ef2a29d40fe77f2e753bd75a5d5d2d141b7fb1286acf0"
+dependencies = [
+ "cgp-field",
+]
+
+[[package]]
 name = "cgp-handler"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94422cf44b5a6fe08d000baa1b0ced4020f0f37703d28a987cfa7aa5e9629d35"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-inner"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2ed2813b5b83be1c33be5e9eab09ca3dd3abc71bce0ba53ce3060c6614e5fe"
 dependencies = [
  "cgp-component",
  "cgp-macro",
@@ -247,8 +259,9 @@ dependencies = [
 
 [[package]]
 name = "cgp-macro"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288db147235ad4feb71701f3112e39e172550499aafd7ba99f78971dae71ee2"
 dependencies = [
  "cgp-macro-lib",
  "syn",
@@ -256,8 +269,9 @@ dependencies = [
 
 [[package]]
 name = "cgp-macro-lib"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5b3bb1edeb244e46f35bc1b3fb2a48c6a463086d9aed519c2e651803cc3e85"
 dependencies = [
  "itertools",
  "prettyplease",
@@ -268,8 +282,9 @@ dependencies = [
 
 [[package]]
 name = "cgp-monad"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f271e9ae7a6dc7949b41c33003d23c4069f0d98eeea6ba0aa3857c69973fc8b"
 dependencies = [
  "cgp-core",
  "cgp-handler",
@@ -277,35 +292,27 @@ dependencies = [
 
 [[package]]
 name = "cgp-run"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
-dependencies = [
- "cgp-async",
- "cgp-component",
- "cgp-error",
- "cgp-macro",
-]
-
-[[package]]
-name = "cgp-runtime"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ae5cf08515730c64280e6fd1a701838a135cc93784586a1f0129ac2f27d9a6"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
-name = "cgp-sync"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+name = "cgp-runtime"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca7746cf1a2035efec24db442e2d88a470fce8bdcc7cfed90dc0d06f8daa3a3"
 dependencies = [
- "cgp-async-macro",
+ "cgp-core",
 ]
 
 [[package]]
 name = "cgp-type"
-version = "0.4.2"
-source = "git+https://github.com/contextgeneric/cgp.git#4f1dfad36d33738adc55921cc74f245dc74979f1"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe19c788be101511c5924fa3d3f1ad44ec0304189b924d092940c6e6a3ba4b0e"
 dependencies = [
  "cgp-component",
  "cgp-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ authors         = ["Soares Chen <soares.chen@maybevoid.com>"]
 keywords        = ["cgp"]
 
 [workspace.dependencies]
-cgp                 = { version = "0.4.2" }
-cgp-error-anyhow    = { version = "0.4.2" }
+cgp                 = { version = "0.5.0-alpha" }
+cgp-error-anyhow    = { version = "0.5.0-alpha" }
 futures             = { version = "0.3.31" }
 hex                 = { version = "0.4.3" }
 itertools           = { version = "0.14.0" }
@@ -58,25 +58,25 @@ hypershell-tungstenite-components   = { path = "./crates/hypershell-tungstenite-
 hypershell-hash-components          = { path = "./crates/hypershell-hash-components" }
 hypershell-macro                    = { path = "./crates/hypershell-macro" }
 
-cgp                         = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-core                    = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-extra                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-async                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-async-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-component               = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-macro                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-macro-lib               = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-extra-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-extra-macro-lib         = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-type                    = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-field                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-error                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-error-extra             = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-run                     = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-runtime                 = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-sync                    = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-inner                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-handler                 = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-monad                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-dispatch                = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-error-anyhow            = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp                         = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-core                    = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-extra                   = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-async                   = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-async-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-component               = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-macro                   = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-macro-lib               = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-extra-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-extra-macro-lib         = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-type                    = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-field                   = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-error                   = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-error-extra             = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-run                     = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-runtime                 = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-sync                    = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-inner                   = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-handler                 = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-monad                   = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-dispatch                = { git = "https://github.com/contextgeneric/cgp.git" }
+# cgp-error-anyhow            = { git = "https://github.com/contextgeneric/cgp.git" }

--- a/crates/hypershell-components/src/providers/box_async.rs
+++ b/crates/hypershell-components/src/providers/box_async.rs
@@ -6,13 +6,12 @@ use cgp::extra::handler::{Handler, HandlerComponent};
 use cgp::prelude::*;
 
 #[cgp_new_provider]
-impl<Context, Code: Send, Input: Send, InHandler> Handler<Context, Code, Input>
-    for BoxHandler<InHandler>
+impl<Context, Code, Input, InHandler> Handler<Context, Code, Input> for BoxHandler<InHandler>
 where
-    Context: HasAsyncErrorType,
-    InHandler: Send + 'static + Handler<Context, Code, Input>,
-    Code: Send + 'static,
-    Input: Send + 'static,
+    Context: HasErrorType,
+    InHandler: 'static + Handler<Context, Code, Input>,
+    Code: 'static,
+    Input: 'static,
 {
     type Output = InHandler::Output;
 
@@ -20,8 +19,8 @@ where
         context: &Context,
         code: PhantomData<Code>,
         input: Input,
-    ) -> impl Future<Output = Result<Self::Output, Context::Error>> + Send {
-        let future: Pin<Box<dyn Future<Output = Result<Self::Output, Context::Error>> + Send>> =
+    ) -> impl Future<Output = Result<Self::Output, Context::Error>> {
+        let future: Pin<Box<dyn Future<Output = Result<Self::Output, Context::Error>>>> =
             Box::pin(InHandler::handle(context, code, input));
 
         future

--- a/crates/hypershell-components/src/providers/call.rs
+++ b/crates/hypershell-components/src/providers/call.rs
@@ -7,9 +7,6 @@ use cgp::prelude::*;
 impl<Context, OutCode, InCode, Input> Handler<Context, OutCode, Input> for Call<InCode>
 where
     Context: CanHandle<InCode, Input>,
-    InCode: Send,
-    OutCode: Send,
-    Input: Send,
 {
     type Output = Context::Output;
 

--- a/crates/hypershell-components/src/providers/convert.rs
+++ b/crates/hypershell-components/src/providers/convert.rs
@@ -24,9 +24,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for DecodeUtf8Bytes
 where
-    Context: CanRaiseAsyncError<Utf8Error> + for<'a> CanWrapAsyncError<DecodeUtf8InputError<'a>>,
-    Code: Send,
-    Input: Send + AsRef<[u8]>,
+    Context: CanRaiseError<Utf8Error> + for<'a> CanWrapError<DecodeUtf8InputError<'a>>,
+    Input: AsRef<[u8]>,
 {
     type Output = String;
 

--- a/crates/hypershell-components/src/providers/return.rs
+++ b/crates/hypershell-components/src/providers/return.rs
@@ -6,9 +6,7 @@ use cgp::prelude::*;
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for ReturnInput
 where
-    Context: HasAsyncErrorType,
-    Code: Send,
-    Input: Send,
+    Context: HasErrorType,
 {
     type Output = Input;
 

--- a/crates/hypershell-components/src/providers/use.rs
+++ b/crates/hypershell-components/src/providers/use.rs
@@ -11,11 +11,8 @@ pub struct HandleUseProvider;
 impl<Context, Provider, Code, Input> Handler<Context, Use<Provider, Code>, Input>
     for HandleUseProvider
 where
-    Context: HasAsyncErrorType,
+    Context: HasErrorType,
     Provider: Handler<Context, Code, Input>,
-    Input: Send,
-    Provider: Send,
-    Code: Send,
 {
     type Output = Provider::Output;
 

--- a/crates/hypershell-examples/src/providers/compare.rs
+++ b/crates/hypershell-examples/src/providers/compare.rs
@@ -7,11 +7,11 @@ use hypershell::prelude::CanHandle;
 use crate::dsl::Compare;
 
 #[cgp_new_provider]
-impl<Context, CodeA: Send, CodeB: Send, InputA: Send, InputB: Send, Output>
+impl<Context, CodeA, CodeB, InputA, InputB, Output>
     Handler<Context, Compare<CodeA, CodeB>, (InputA, InputB)> for HandleCompare
 where
     Context: CanHandle<CodeA, InputA, Output = Output> + CanHandle<CodeB, InputB, Output = Output>,
-    Output: Send + Eq,
+    Output: Eq,
 {
     type Output = bool;
 

--- a/crates/hypershell-examples/src/providers/if.rs
+++ b/crates/hypershell-examples/src/providers/if.rs
@@ -7,15 +7,8 @@ use hypershell::prelude::CanHandle;
 use crate::dsl::If;
 
 #[cgp_new_provider]
-impl<
-    Context,
-    CodeCond: Send,
-    CodeThen: Send,
-    CodeElse: Send,
-    InputCond: Send,
-    InputBranch: Send,
-    Output: Send,
-> Handler<Context, If<CodeCond, CodeThen, CodeElse>, (InputCond, InputBranch)> for HandleIf
+impl<Context, CodeCond, CodeThen, CodeElse, InputCond, InputBranch, Output>
+    Handler<Context, If<CodeCond, CodeThen, CodeElse>, (InputCond, InputBranch)> for HandleIf
 where
     Context: CanHandle<CodeCond, InputCond, Output = bool>
         + CanHandle<CodeThen, InputBranch, Output = Output>

--- a/crates/hypershell-hash-components/src/providers/bytes_to_hex.rs
+++ b/crates/hypershell-hash-components/src/providers/bytes_to_hex.rs
@@ -6,9 +6,8 @@ use cgp::prelude::*;
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for HandleBytesToHex
 where
-    Context: HasAsyncErrorType,
-    Code: Send,
-    Input: Send + AsRef<[u8]>,
+    Context: HasErrorType,
+    Input: AsRef<[u8]>,
 {
     type Output = String;
 

--- a/crates/hypershell-hash-components/src/providers/stream_checksum.rs
+++ b/crates/hypershell-hash-components/src/providers/stream_checksum.rs
@@ -11,9 +11,9 @@ use crate::dsl::Checksum;
 #[cgp_new_provider]
 impl<Context, Input, Hasher> Handler<Context, Checksum<Hasher>, Input> for HandleStreamChecksum
 where
-    Context: CanRaiseAsyncError<Input::Error>,
-    Input: Send + Unpin + TryStream,
-    Hasher: Send + Digest,
+    Context: CanRaiseError<Input::Error>,
+    Input: Unpin + TryStream,
+    Hasher: Digest,
     Input::Ok: AsRef<[u8]>,
 {
     type Output = GenericArray<u8, Hasher::OutputSize>;

--- a/crates/hypershell-json-components/src/providers/handler.rs
+++ b/crates/hypershell-json-components/src/providers/handler.rs
@@ -10,9 +10,9 @@ use serde::de::DeserializeOwned;
 #[cgp_new_provider]
 impl<Context, Input, Output> Handler<Context, DecodeJson<Output>, Input> for HandleDecodeJson
 where
-    Context: CanRaiseAsyncError<serde_json::Error>,
-    Input: Send + AsRef<[u8]>,
-    Output: Send + DeserializeOwned,
+    Context: CanRaiseError<serde_json::Error>,
+    Input: AsRef<[u8]>,
+    Output: DeserializeOwned,
 {
     type Output = Output;
 
@@ -29,9 +29,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for HandleEncodeJson
 where
-    Context: CanRaiseAsyncError<serde_json::Error>,
-    Input: Send + Serialize,
-    Code: Send,
+    Context: CanRaiseError<serde_json::Error>,
+    Input: Serialize,
 {
     type Output = Vec<u8>;
 

--- a/crates/hypershell-reqwest-components/src/providers/convert.rs
+++ b/crates/hypershell-reqwest-components/src/providers/convert.rs
@@ -9,9 +9,8 @@ use tokio_util::io::ReaderStream;
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for StreamToBody
 where
-    Context: HasAsyncErrorType,
+    Context: HasErrorType,
     Input: Send + AsyncRead + 'static,
-    Code: Send,
 {
     type Output = Body;
 

--- a/crates/hypershell-reqwest-components/src/providers/core_request.rs
+++ b/crates/hypershell-reqwest-components/src/providers/core_request.rs
@@ -16,11 +16,8 @@ where
         + CanExtractUrlArg<UrlArg, Url = Url>
         + CanExtractMethodArg<MethodArg, HttpMethod = Method>
         + CanUpdateRequestBuilder<Headers>
-        + CanRaiseAsyncError<reqwest::Error>,
-    MethodArg: Send,
-    UrlArg: Send,
-    Headers: Send,
-    Input: Send + Into<Body>,
+        + CanRaiseError<reqwest::Error>,
+    Input: Into<Body>,
 {
     type Output = Response;
 

--- a/crates/hypershell-reqwest-components/src/providers/simple_request.rs
+++ b/crates/hypershell-reqwest-components/src/providers/simple_request.rs
@@ -18,12 +18,8 @@ impl<Context, MethodArg, UrlArg, Headers, Input>
     for HandleSimpleHttpRequest
 where
     Context: CanHandle<CoreHttpRequest<MethodArg, UrlArg, Headers>, Input, Output = Response>
-        + CanRaiseAsyncError<reqwest::Error>
-        + CanRaiseAsyncError<ErrorResponse>,
-    MethodArg: Send,
-    UrlArg: Send,
-    Headers: Send,
-    Input: Send,
+        + CanRaiseError<reqwest::Error>
+        + CanRaiseError<ErrorResponse>,
 {
     type Output = Vec<u8>;
 

--- a/crates/hypershell-reqwest-components/src/providers/streaming_request.rs
+++ b/crates/hypershell-reqwest-components/src/providers/streaming_request.rs
@@ -17,12 +17,8 @@ impl<Context, MethodArg, UrlArg, Headers, Input>
     for HandleStreamingHttpRequest
 where
     Context: CanHandle<CoreHttpRequest<MethodArg, UrlArg, Headers>, Input, Output = Response>
-        + CanRaiseAsyncError<reqwest::Error>
-        + CanRaiseAsyncError<ErrorResponse>,
-    MethodArg: Send,
-    UrlArg: Send,
-    Headers: Send,
-    Input: Send,
+        + CanRaiseError<reqwest::Error>
+        + CanRaiseError<ErrorResponse>,
 {
     type Output = Pin<Box<dyn FutAsyncRead + Send>>;
 

--- a/crates/hypershell-tokio-components/src/providers/core_exec.rs
+++ b/crates/hypershell-tokio-components/src/providers/core_exec.rs
@@ -17,15 +17,13 @@ use crate::dsl::CoreExec;
 impl<Context, CommandPath, Args> Handler<Context, CoreExec<CommandPath, Args>, ()>
     for HandleCoreExec
 where
-    Context: HasAsyncErrorType
+    Context: HasErrorType
         + CanExtractCommandArg<CommandPath>
         + CanUpdateCommand<Args>
-        + CanRaiseAsyncError<std::io::Error>
-        + for<'a> CanWrapAsyncError<CommandNotFound<'a>>
-        + for<'a> CanWrapAsyncError<SpawnCommandFailure<'a>>,
-    Context::CommandArg: AsRef<OsStr> + Send,
-    CommandPath: Send,
-    Args: Send,
+        + CanRaiseError<std::io::Error>
+        + for<'a> CanWrapError<CommandNotFound<'a>>
+        + for<'a> CanWrapError<SpawnCommandFailure<'a>>,
+    Context::CommandArg: AsRef<OsStr>,
 {
     type Output = Child;
 

--- a/crates/hypershell-tokio-components/src/providers/file.rs
+++ b/crates/hypershell-tokio-components/src/providers/file.rs
@@ -11,9 +11,8 @@ use tokio::io::AsyncRead;
 #[cgp_new_provider]
 impl<Context, PathArg> Handler<Context, ReadFile<PathArg>, ()> for HandleReadFile
 where
-    Context: CanExtractCommandArg<PathArg> + CanRaiseAsyncError<std::io::Error>,
-    PathArg: Send,
-    Context::CommandArg: Send + AsRef<Path>,
+    Context: CanExtractCommandArg<PathArg> + CanRaiseError<std::io::Error>,
+    Context::CommandArg: AsRef<Path>,
 {
     type Output = File;
 
@@ -35,10 +34,9 @@ where
 #[cgp_new_provider]
 impl<Context, PathArg, Input> Handler<Context, WriteFile<PathArg>, Input> for HandleWriteFile
 where
-    Context: CanExtractCommandArg<PathArg> + CanRaiseAsyncError<std::io::Error>,
-    PathArg: Send,
-    Context::CommandArg: Send + AsRef<Path>,
-    Input: Send + AsyncRead + Unpin,
+    Context: CanExtractCommandArg<PathArg> + CanRaiseError<std::io::Error>,
+    Context::CommandArg: AsRef<Path>,
+    Input: AsyncRead + Unpin,
 {
     type Output = ();
 

--- a/crates/hypershell-tokio-components/src/providers/line.rs
+++ b/crates/hypershell-tokio-components/src/providers/line.rs
@@ -10,17 +10,16 @@ use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
 #[cgp_new_provider]
 impl<Context, Input> Handler<Context, StreamToLines, Input> for HandleStreamToLines
 where
-    Context: HasAsyncErrorType,
-    Input: Send + AsyncRead + Unpin + 'static,
+    Context: HasErrorType,
+    Input: AsyncRead + Unpin + 'static,
 {
-    type Output = Box<dyn Stream<Item = Result<String, LinesCodecError>> + Send>;
+    type Output = Box<dyn Stream<Item = Result<String, LinesCodecError>>>;
 
     async fn handle(
         _context: &Context,
         _tag: PhantomData<StreamToLines>,
         input: Input,
-    ) -> Result<Box<dyn Stream<Item = Result<String, LinesCodecError>> + Send>, Context::Error>
-    {
+    ) -> Result<Box<dyn Stream<Item = Result<String, LinesCodecError>>>, Context::Error> {
         let stream = FramedRead::new(input, LinesCodec::new());
 
         Ok(Box::new(stream))

--- a/crates/hypershell-tokio-components/src/providers/out.rs
+++ b/crates/hypershell-tokio-components/src/providers/out.rs
@@ -8,8 +8,8 @@ use tokio::io::{AsyncRead, copy};
 #[cgp_new_provider]
 impl<Context, Input> Handler<Context, StreamToStdout, Input> for HandleStreamToStdout
 where
-    Context: CanRaiseAsyncError<std::io::Error>,
-    Input: Send + AsyncRead + Unpin,
+    Context: CanRaiseError<std::io::Error>,
+    Input: AsyncRead + Unpin,
 {
     type Output = ();
 

--- a/crates/hypershell-tokio-components/src/providers/simple_exec.rs
+++ b/crates/hypershell-tokio-components/src/providers/simple_exec.rs
@@ -19,12 +19,10 @@ impl<Context, CommandPath, Args, Input> Handler<Context, SimpleExec<CommandPath,
     for HandleSimpleExec
 where
     Context: CanHandle<CoreExec<CommandPath, Args>, (), Output = Child>
-        + for<'a> CanRaiseAsyncError<ExecOutputError>
-        + CanWrapAsyncError<StdinPipeError>
-        + CanWrapAsyncError<WaitWithOutputError>
-        + CanRaiseAsyncError<std::io::Error>,
-    CommandPath: Send,
-    Args: Send,
+        + for<'a> CanRaiseError<ExecOutputError>
+        + CanWrapError<StdinPipeError>
+        + CanWrapError<WaitWithOutputError>
+        + CanRaiseError<std::io::Error>,
     Input: Send + AsRef<[u8]>,
 {
     type Output = Vec<u8>;

--- a/crates/hypershell-tokio-components/src/providers/stream.rs
+++ b/crates/hypershell-tokio-components/src/providers/stream.rs
@@ -16,9 +16,8 @@ use crate::types::{FuturesAsyncReadStream, FuturesStream, TokioAsyncReadStream};
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for HandleTokioAsyncReadToBytes
 where
-    Context: CanRaiseAsyncError<std::io::Error>,
-    Input: Send + TokioAsyncRead + Unpin,
-    Code: Send,
+    Context: CanRaiseError<std::io::Error>,
+    Input: TokioAsyncRead + Unpin,
 {
     type Output = Vec<u8>;
 
@@ -41,9 +40,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for HandleTokioAsyncReadToString
 where
-    Context: CanRaiseAsyncError<std::io::Error>,
-    Input: Send + TokioAsyncRead + Unpin,
-    Code: Send,
+    Context: CanRaiseError<std::io::Error>,
+    Input: TokioAsyncRead + Unpin,
 {
     type Output = String;
 
@@ -66,9 +64,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for HandleBytesToTokioAsyncRead
 where
-    Context: CanRaiseAsyncError<std::io::Error>,
-    Input: Send + AsRef<[u8]> + Unpin,
-    Code: Send,
+    Context: CanRaiseError<std::io::Error>,
+    Input: AsRef<[u8]> + Unpin,
 {
     type Output = TokioAsyncReadStream<Compat<Cursor<Input>>>;
 
@@ -84,9 +81,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for HandleBytesToStream
 where
-    Context: CanRaiseAsyncError<std::io::Error>,
-    Input: Send + AsRef<[u8]> + Unpin,
-    Code: Send,
+    Context: CanRaiseError<std::io::Error>,
+    Input: AsRef<[u8]> + Unpin,
 {
     type Output = FuturesStream<Iter<Once<Result<Input, Infallible>>>>;
 
@@ -102,9 +98,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for FuturesToTokioAsyncRead
 where
-    Context: HasAsyncErrorType,
-    Input: Send + FuturesAsyncRead + Unpin,
-    Code: Send,
+    Context: HasErrorType,
+    Input: FuturesAsyncRead + Unpin,
 {
     type Output = TokioAsyncReadStream<Compat<Input>>;
 
@@ -120,9 +115,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for TokioToFuturesAsyncRead
 where
-    Context: HasAsyncErrorType,
-    Input: Send + TokioAsyncRead + Unpin,
-    Code: Send,
+    Context: HasErrorType,
+    Input: TokioAsyncRead + Unpin,
 {
     type Output = FuturesAsyncReadStream<Compat<Input>>;
 
@@ -138,9 +132,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for WrapTokioAsyncRead
 where
-    Context: HasAsyncErrorType,
-    Input: Send + TokioAsyncRead + Unpin,
-    Code: Send,
+    Context: HasErrorType,
+    Input: TokioAsyncRead + Unpin,
 {
     type Output = TokioAsyncReadStream<Input>;
 
@@ -156,9 +149,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for WrapFuturesAsyncRead
 where
-    Context: HasAsyncErrorType,
-    Input: Send + FuturesAsyncRead + Unpin,
-    Code: Send,
+    Context: HasErrorType,
+    Input: FuturesAsyncRead + Unpin,
 {
     type Output = FuturesAsyncReadStream<Input>;
 
@@ -174,9 +166,8 @@ where
 #[cgp_new_provider]
 impl<Context, Code, Input> Handler<Context, Code, Input> for AsyncReadToStream
 where
-    Context: HasAsyncErrorType,
-    Input: Send + TokioAsyncRead + Unpin,
-    Code: Send,
+    Context: HasErrorType,
+    Input: TokioAsyncRead + Unpin,
 {
     type Output = FuturesStream<ReaderStream<Input>>;
 

--- a/crates/hypershell-tokio-components/src/providers/streaming_exec.rs
+++ b/crates/hypershell-tokio-components/src/providers/streaming_exec.rs
@@ -14,10 +14,8 @@ use crate::dsl::CoreExec;
 impl<Context, CommandPath, Args, Input> Handler<Context, StreamingExec<CommandPath, Args>, Input>
     for HandleStreamingExec
 where
-    Context: CanHandle<CoreExec<CommandPath, Args>, (), Output = Child>
-        + CanRaiseAsyncError<std::io::Error>,
-    CommandPath: Send,
-    Args: Send,
+    Context:
+        CanHandle<CoreExec<CommandPath, Args>, (), Output = Child> + CanRaiseError<std::io::Error>,
     Input: Send + Unpin + AsyncRead + 'static,
 {
     type Output = Either<ChildStdout, Empty>;

--- a/crates/hypershell-tungstenite-components/src/providers/websocket.rs
+++ b/crates/hypershell-tungstenite-components/src/providers/websocket.rs
@@ -19,9 +19,7 @@ use tokio_util::io::ReaderStream;
 impl<Context, UrlArg, Headers, Input> Handler<Context, WebSocket<UrlArg, Headers>, Input>
     for HandleWebsocket
 where
-    Context: CanExtractStringArg<UrlArg> + CanRaiseAsyncError<tungstenite::Error>,
-    UrlArg: Send,
-    Headers: Send,
+    Context: CanExtractStringArg<UrlArg> + CanRaiseError<tungstenite::Error>,
     Input: Send + AsyncRead + Unpin + 'static,
 {
     type Output = Pin<Box<dyn FuturesAsyncRead + Send>>;


### PR DESCRIPTION
# Summary

This PR updates Hypershell to v0.5.0-alpha. 

We also remove most of the `Send` bounds following changes in https://github.com/contextgeneric/cgp/pull/149. There are still a few `Send` bounds remaining due to the use of `Box<dyn AsyncRead>` that makes it not possible to recover the `Send` bound from the concrete type. To remove the boxes, we may need [type alias in impl trait](https://rust-lang.github.io/rfcs/2515-type_alias_impl_trait.html), or something similar that can allow us to not name the full `AsyncRead` type as the `Output` type.