### PR TITLE
Use `#[cgp_impl]` and remove `#[cgp_context]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,8 +101,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cgp"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808e618db803f54e4222fffa79a773285c00db6766977d3cacae793eca9b1577"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
  "cgp-extra",
@@ -111,8 +110,7 @@ dependencies = [
 [[package]]
 name = "cgp-async-macro"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c854822d7b7700c223e648f2e2b3b8dea47e53aa858db7dc7a805adb211205"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -122,14 +120,12 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabbf574096bd7a9a79cc0f24989f49060aaf7f86bce2756fb7cc3e096ad59f2"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 
 [[package]]
 name = "cgp-core"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16d4a2a938b2b11d078f10b4893b8295027c616ec6134fa09e877580f9d95c8"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-async-macro",
  "cgp-component",
@@ -142,8 +138,7 @@ dependencies = [
 [[package]]
 name = "cgp-dispatch"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be0990bad684ba4e40aa8fc73c8138ea28ca3f6068f336af8a82813250a6fa0"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
  "cgp-handler",
@@ -153,8 +148,7 @@ dependencies = [
 [[package]]
 name = "cgp-error"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613b07f14aef847187014d72eb462f59667661cbe614ae249ce34c380f7ff2f9"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-component",
  "cgp-macro",
@@ -164,8 +158,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-anyhow"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb9fb8c72a75459069308e724c8a747193d7879c2c79d22effbfdef118cdd9b"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "anyhow",
  "cgp-core",
@@ -174,8 +167,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-extra"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eeff288cf174bb131fe3bc1e2d6038a68bf7fcc720e2e02589b6466c0112d94"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
 ]
@@ -183,8 +175,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc7f97cd02144bf566a8dca6a11a806efccb6637240ffe953c26462dd1bd0b0"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
  "cgp-dispatch",
@@ -200,8 +191,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra-macro"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda176978a134ef8554fd7e256666e898f62e43b882c407cc2bff47c00f8b0d"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-extra-macro-lib",
  "syn",
@@ -210,8 +200,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra-macro-lib"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546ce09e1bf7ff8e874740fafcbe522cb900beb831e24676fd634c4836c1ecc5"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -221,8 +210,7 @@ dependencies = [
 [[package]]
 name = "cgp-field"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd42a320b4b4d020114fe25874c313e662b514354c7e0bf0e3298754216cb48f"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-component",
  "cgp-type",
@@ -231,8 +219,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-extra"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6d86f16a5f5ba3ef0464d646b3fc6f085d97af0cb817c0dc6b3ca5d3bbe83f"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-field",
 ]
@@ -240,8 +227,7 @@ dependencies = [
 [[package]]
 name = "cgp-handler"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d7e0e09206a6abf88eefbe04d9017b2ab53e18a0b9a3039933b2a8ee8c660b"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
 ]
@@ -249,8 +235,7 @@ dependencies = [
 [[package]]
 name = "cgp-macro"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e440bf54f108b91f177dae8801b5e810fb413709b6732d0ada37ba47aebf407"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-macro-lib",
  "syn",
@@ -259,8 +244,7 @@ dependencies = [
 [[package]]
 name = "cgp-macro-lib"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86884fa366cc3d2f0bef610c9a6ce2b48451ed101eac0c300104029af96f1e7"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "itertools",
  "prettyplease",
@@ -272,8 +256,7 @@ dependencies = [
 [[package]]
 name = "cgp-monad"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448e04f87f64ba6677de22559a422f04b4f2cb29fb62b16dbe5ed7677d873fb3"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
  "cgp-handler",
@@ -282,8 +265,7 @@ dependencies = [
 [[package]]
 name = "cgp-run"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8c0e58e0e4f373405143799892ee37101174a83fe9e00ad8d2d22cd4cbedd9"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
 ]
@@ -291,8 +273,7 @@ dependencies = [
 [[package]]
 name = "cgp-runtime"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f98e8d13664dcd0d809b945b982a934001adcf2e99875b88a1a4985f450375c"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-core",
 ]
@@ -300,8 +281,7 @@ dependencies = [
 [[package]]
 name = "cgp-type"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301243ad41daca746950f71ab9ae257836bbbb0a7004990a601a9726ade5be23"
+source = "git+https://github.com/contextgeneric/cgp.git#3b8befaffb2d2624cba32f2a62359040c59a8ba1"
 dependencies = [
  "cgp-component",
  "cgp-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,5 @@ hypershell-tungstenite-components   = { path = "./crates/hypershell-tungstenite-
 hypershell-hash-components          = { path = "./crates/hypershell-hash-components" }
 hypershell-macro                    = { path = "./crates/hypershell-macro" }
 
-# cgp                         = { git = "https://github.com/contextgeneric/cgp.git", branch = "v0.5.0-release" }
-# cgp-error-anyhow            = { git = "https://github.com/contextgeneric/cgp.git", branch = "v0.5.0-release" }
+cgp                         = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-error-anyhow            = { git = "https://github.com/contextgeneric/cgp.git" }

--- a/crates/hypershell-components/src/providers/box_async.rs
+++ b/crates/hypershell-components/src/providers/box_async.rs
@@ -5,8 +5,8 @@ use core::pin::Pin;
 use cgp::extra::handler::{Handler, HandlerComponent};
 use cgp::prelude::*;
 
-#[cgp_new_provider]
-impl<Context, Code, Input, InHandler> Handler<Context, Code, Input> for BoxHandler<InHandler>
+#[cgp_impl(new BoxHandler<InHandler>)]
+impl<Context, Code, Input, InHandler> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     InHandler: 'static + Handler<Context, Code, Input>,

--- a/crates/hypershell-components/src/providers/call.rs
+++ b/crates/hypershell-components/src/providers/call.rs
@@ -3,8 +3,8 @@ use core::marker::PhantomData;
 use cgp::extra::handler::{CanHandle, Handler, HandlerComponent};
 use cgp::prelude::*;
 
-#[cgp_new_provider]
-impl<Context, OutCode, InCode, Input> Handler<Context, OutCode, Input> for Call<InCode>
+#[cgp_impl(new Call<InCode>)]
+impl<Context, OutCode, InCode, Input> Handler<OutCode, Input> for Context
 where
     Context: CanHandle<InCode, Input>,
 {

--- a/crates/hypershell-components/src/providers/convert.rs
+++ b/crates/hypershell-components/src/providers/convert.rs
@@ -9,8 +9,8 @@ use cgp::prelude::*;
 
 use crate::dsl::ConvertTo;
 
-#[cgp_new_provider]
-impl<Context, Input, Output> Computer<Context, ConvertTo<Output>, Input> for HandleConvert
+#[cgp_impl(new HandleConvert)]
+impl<Context, Input, Output> Computer<ConvertTo<Output>, Input> for Context
 where
     Input: Into<Output>,
 {
@@ -21,8 +21,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for DecodeUtf8Bytes
+#[cgp_impl(new DecodeUtf8Bytes)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: CanRaiseError<Utf8Error> + for<'a> CanWrapError<DecodeUtf8InputError<'a>>,
     Input: AsRef<[u8]>,

--- a/crates/hypershell-components/src/providers/method_arg.rs
+++ b/crates/hypershell-components/src/providers/method_arg.rs
@@ -5,8 +5,8 @@ use cgp::prelude::*;
 use crate::components::{HasHttpMethodType, MethodArgExtractor, MethodArgExtractorComponent};
 use crate::dsl::FieldArg;
 
-#[cgp_new_provider]
-impl<Context, Tag> MethodArgExtractor<Context, FieldArg<Tag>> for ExtractMethodFieldArg
+#[cgp_impl(new ExtractMethodFieldArg)]
+impl<Context, Tag> MethodArgExtractor<FieldArg<Tag>> for Context
 where
     Context: HasHttpMethodType + HasField<Tag, Value = Context::HttpMethod>,
     Context::HttpMethod: Clone,

--- a/crates/hypershell-components/src/providers/return.rs
+++ b/crates/hypershell-components/src/providers/return.rs
@@ -3,8 +3,8 @@ use core::marker::PhantomData;
 use cgp::extra::handler::{Handler, HandlerComponent};
 use cgp::prelude::*;
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for ReturnInput
+#[cgp_impl(new ReturnInput)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
 {

--- a/crates/hypershell-components/src/providers/string_arg.rs
+++ b/crates/hypershell-components/src/providers/string_arg.rs
@@ -12,8 +12,8 @@ use crate::components::{
 };
 use crate::dsl::{FieldArg, JoinArgs, StaticArg};
 
-#[cgp_new_provider]
-impl<Context, Arg> CommandArgExtractor<Context, Arg> for ExtractStringCommandArg
+#[cgp_impl(new ExtractStringCommandArg)]
+impl<Context, Arg> CommandArgExtractor<Arg> for Context
 where
     Context: HasCommandArgType + CanExtractStringArg<Arg>,
     Context::CommandArg: From<String>,
@@ -23,8 +23,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Arg> StringArgExtractor<Context, StaticArg<Arg>> for ExtractStaticArg
+#[cgp_impl(new ExtractStaticArg)]
+impl<Context, Arg> StringArgExtractor<StaticArg<Arg>> for Context
 where
     Arg: Default + Display,
 {
@@ -36,8 +36,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Tag> StringArgExtractor<Context, FieldArg<Tag>> for ExtractFieldArg
+#[cgp_impl(new ExtractFieldArg)]
+impl<Context, Tag> StringArgExtractor<FieldArg<Tag>> for Context
 where
     Context: HasField<Tag, Value: Display>,
 {
@@ -48,25 +48,25 @@ where
 
 pub struct JoinStringArgs;
 
-#[cgp_provider]
-impl<Context, Arg, Args> StringArgExtractor<Context, JoinArgs<Cons<Arg, Args>>> for JoinStringArgs
+#[cgp_impl(JoinStringArgs)]
+impl<Context, Arg, Args> StringArgExtractor<JoinArgs<Cons<Arg, Args>>> for Context
 where
     Context: CanExtractStringArg<Arg>,
-    Self: StringArgExtractor<Context, JoinArgs<Args>>,
+    JoinStringArgs: StringArgExtractor<Context, JoinArgs<Args>>,
 {
     fn extract_string_arg(
         context: &Context,
         _phantom: PhantomData<JoinArgs<Cons<Arg, Args>>>,
     ) -> Cow<'_, str> {
         let arg = context.extract_string_arg(PhantomData);
-        let args = Self::extract_string_arg(context, PhantomData::<JoinArgs<Args>>);
+        let args = JoinStringArgs::extract_string_arg(context, PhantomData::<JoinArgs<Args>>);
 
         format!("{arg}{args}").into()
     }
 }
 
-#[cgp_provider]
-impl<Context> StringArgExtractor<Context, JoinArgs<Nil>> for JoinStringArgs {
+#[cgp_impl(JoinStringArgs)]
+impl<Context> StringArgExtractor<JoinArgs<Nil>> for Context {
     fn extract_string_arg(
         _context: &Context,
         _phantom: PhantomData<JoinArgs<Nil>>,

--- a/crates/hypershell-components/src/providers/url_arg.rs
+++ b/crates/hypershell-components/src/providers/url_arg.rs
@@ -8,8 +8,8 @@ use crate::components::{
 };
 use crate::dsl::FieldArg;
 
-#[cgp_new_provider]
-impl<Context, Arg> UrlArgExtractor<Context, Arg> for ExtractStringUrlArg
+#[cgp_impl(new ExtractStringUrlArg)]
+impl<Context, Arg> UrlArgExtractor<Arg> for Context
 where
     Context: HasUrlType + CanExtractStringArg<Arg> + CanRaiseError<<Context::Url as FromStr>::Err>,
     Context::Url: FromStr,
@@ -23,8 +23,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Tag> UrlArgExtractor<Context, FieldArg<Tag>> for ExtractUrlFieldArg
+#[cgp_impl(new ExtractUrlFieldArg)]
+impl<Context, Tag> UrlArgExtractor<FieldArg<Tag>> for Context
 where
     Context: HasUrlType + HasErrorType + HasField<Tag, Value = Context::Url>,
     Context::Url: Clone,

--- a/crates/hypershell-components/src/providers/use.rs
+++ b/crates/hypershell-components/src/providers/use.rs
@@ -5,11 +5,8 @@ use cgp::prelude::*;
 
 use crate::dsl::Use;
 
-pub struct HandleUseProvider;
-
-#[cgp_provider]
-impl<Context, Provider, Code, Input> Handler<Context, Use<Provider, Code>, Input>
-    for HandleUseProvider
+#[cgp_impl(new HandleUseProvider)]
+impl<Context, Provider, Code, Input> Handler<Use<Provider, Code>, Input> for Context
 where
     Context: HasErrorType,
     Provider: Handler<Context, Code, Input>,

--- a/crates/hypershell-examples/examples/bluesky.rs
+++ b/crates/hypershell-examples/examples/bluesky.rs
@@ -47,7 +47,7 @@ pub type Program = hypershell! {
     |   StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub keyword: String,

--- a/crates/hypershell-examples/examples/bluesky_websocket.rs
+++ b/crates/hypershell-examples/examples/bluesky_websocket.rs
@@ -46,7 +46,7 @@ pub type Program = hypershell! {
     |   StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: MyAppPreset)]
+#[cgp_inherit(MyAppPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub keyword: String,

--- a/crates/hypershell-examples/examples/compare_and_branch.rs
+++ b/crates/hypershell-examples/examples/compare_and_branch.rs
@@ -39,7 +39,7 @@ pub type Program = hypershell! {
     | StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: HypershellComparePreset)]
+#[cgp_inherit(HypershellComparePreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub http_client: Client,

--- a/crates/hypershell-examples/examples/github_issues.rs
+++ b/crates/hypershell-examples/examples/github_issues.rs
@@ -18,7 +18,7 @@
 //    the JSON byte stream into a `Vec<Issue>`.
 //
 // The `MyApp` struct defines the context for running the Hypershell program.
-// It uses `#[cgp_context]` to inherit the necessary components from
+// It uses `#[cgp_inherit]` to inherit the necessary components from
 // `HypershellPreset` for executing the program. It also uses `#[derive(HasField)]`
 // to expose its fields to be used by `FieldArg` within the program definition.
 //
@@ -51,7 +51,7 @@ pub type Program = hypershell! {
     | DecodeJson<Vec<Issue>>
 };
 
-#[cgp_context(MyAppComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub http_client: Client,

--- a/crates/hypershell-examples/examples/hello_name.rs
+++ b/crates/hypershell-examples/examples/hello_name.rs
@@ -18,7 +18,7 @@
 // 5. The output is piped to `StreamToStdout`.
 //
 // To provide the dynamic `name` argument, a custom `MyApp` context is defined
-// with a `name` field. The `#[cgp_context]` macro wires it up with the
+// with a `name` field. The `#[cgp_inherit]` macro wires it up with the
 // `HypershellPreset`, and `#[derive(HasField)]` makes its fields accessible
 // to `FieldArg`.
 //
@@ -38,7 +38,7 @@ pub type Program = hypershell! {
     |   StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub name: String,

--- a/crates/hypershell-examples/examples/http_checksum_cli.rs
+++ b/crates/hypershell-examples/examples/http_checksum_cli.rs
@@ -51,7 +51,7 @@ pub type Program = hypershell! {
     | StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub url: String,

--- a/crates/hypershell-examples/examples/http_checksum_client.rs
+++ b/crates/hypershell-examples/examples/http_checksum_client.rs
@@ -51,7 +51,7 @@ pub type Program = hypershell! {
     | StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub http_client: Client,

--- a/crates/hypershell-examples/examples/http_checksum_native.rs
+++ b/crates/hypershell-examples/examples/http_checksum_native.rs
@@ -47,7 +47,7 @@ pub type Program = hypershell! {
     | StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: HypershellChecksumPreset)]
+#[cgp_inherit(HypershellChecksumPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub http_client: Client,

--- a/crates/hypershell-examples/examples/nix_manual.rs
+++ b/crates/hypershell-examples/examples/nix_manual.rs
@@ -51,7 +51,7 @@ pub type Program = hypershell! {
     | StreamToStdout
 };
 
-#[cgp_context(MyAppComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub http_client: Client,

--- a/crates/hypershell-examples/examples/parallel_compare.rs
+++ b/crates/hypershell-examples/examples/parallel_compare.rs
@@ -24,7 +24,7 @@ pub type Program = hypershell! {
     >
 };
 
-#[cgp_context(MyAppComponents: HypershellComparePreset)]
+#[cgp_inherit(HypershellComparePreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub http_client: Client,

--- a/crates/hypershell-examples/examples/save_webpage.rs
+++ b/crates/hypershell-examples/examples/save_webpage.rs
@@ -31,7 +31,7 @@ pub type Program = hypershell! {
     |   WriteFile<FieldArg<"file_path">>
 };
 
-#[cgp_context(MyAppComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct MyApp {
     pub http_client: Client,

--- a/crates/hypershell-examples/src/providers/compare.rs
+++ b/crates/hypershell-examples/src/providers/compare.rs
@@ -6,9 +6,9 @@ use hypershell::prelude::CanHandle;
 
 use crate::dsl::Compare;
 
-#[cgp_new_provider]
-impl<Context, CodeA, CodeB, InputA, InputB, Output>
-    Handler<Context, Compare<CodeA, CodeB>, (InputA, InputB)> for HandleCompare
+#[cgp_impl(new HandleCompare)]
+impl<Context, CodeA, CodeB, InputA, InputB, Output> Handler<Compare<CodeA, CodeB>, (InputA, InputB)>
+    for Context
 where
     Context: CanHandle<CodeA, InputA, Output = Output> + CanHandle<CodeB, InputB, Output = Output>,
     Output: Eq,

--- a/crates/hypershell-examples/src/providers/if.rs
+++ b/crates/hypershell-examples/src/providers/if.rs
@@ -6,9 +6,9 @@ use hypershell::prelude::CanHandle;
 
 use crate::dsl::If;
 
-#[cgp_new_provider]
+#[cgp_impl(new HandleIf)]
 impl<Context, CodeCond, CodeThen, CodeElse, InputCond, InputBranch, Output>
-    Handler<Context, If<CodeCond, CodeThen, CodeElse>, (InputCond, InputBranch)> for HandleIf
+    Handler<If<CodeCond, CodeThen, CodeElse>, (InputCond, InputBranch)> for Context
 where
     Context: CanHandle<CodeCond, InputCond, Output = bool>
         + CanHandle<CodeThen, InputBranch, Output = Output>

--- a/crates/hypershell-examples/tests/tests/field.rs
+++ b/crates/hypershell-examples/tests/tests/field.rs
@@ -3,7 +3,7 @@ use hypershell::presets::HypershellPreset;
 
 #[tokio::test]
 async fn test_join_fields() -> Result<(), Error> {
-    #[cgp_context(TestAppComponents: HypershellPreset)]
+    #[cgp_inherit(HypershellPreset)]
     #[derive(HasField)]
     pub struct TestApp {
         pub base_dir: String,
@@ -36,7 +36,7 @@ async fn test_join_fields() -> Result<(), Error> {
 
 #[tokio::test]
 async fn test_field_args() -> Result<(), Error> {
-    #[cgp_context(TestAppComponents: HypershellPreset)]
+    #[cgp_inherit(HypershellPreset)]
     #[derive(HasField)]
     pub struct TestApp<'a> {
         pub args: Vec<&'a str>,

--- a/crates/hypershell-examples/tests/tests/pipe.rs
+++ b/crates/hypershell-examples/tests/tests/pipe.rs
@@ -3,7 +3,7 @@ use hypershell::presets::HypershellPreset;
 
 #[tokio::test]
 async fn test_simple_pipe() -> Result<(), Error> {
-    #[cgp_context(TestAppComponents: HypershellPreset)]
+    #[cgp_inherit(HypershellPreset)]
     #[derive(HasField)]
     pub struct TestApp {
         pub base_dir: String,

--- a/crates/hypershell-hash-components/src/providers/bytes_to_hex.rs
+++ b/crates/hypershell-hash-components/src/providers/bytes_to_hex.rs
@@ -3,8 +3,8 @@ use core::marker::PhantomData;
 use cgp::extra::handler::{Handler, HandlerComponent};
 use cgp::prelude::*;
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for HandleBytesToHex
+#[cgp_impl(new HandleBytesToHex)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     Input: AsRef<[u8]>,

--- a/crates/hypershell-hash-components/src/providers/stream_checksum.rs
+++ b/crates/hypershell-hash-components/src/providers/stream_checksum.rs
@@ -8,8 +8,8 @@ use sha2::digest::generic_array::GenericArray;
 
 use crate::dsl::Checksum;
 
-#[cgp_new_provider]
-impl<Context, Input, Hasher> Handler<Context, Checksum<Hasher>, Input> for HandleStreamChecksum
+#[cgp_impl(new HandleStreamChecksum)]
+impl<Context, Input, Hasher> Handler<Checksum<Hasher>, Input> for Context
 where
     Context: CanRaiseError<Input::Error>,
     Input: Unpin + TryStream,

--- a/crates/hypershell-json-components/src/providers/handler.rs
+++ b/crates/hypershell-json-components/src/providers/handler.rs
@@ -7,8 +7,8 @@ use hypershell_components::dsl::DecodeJson;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-#[cgp_new_provider]
-impl<Context, Input, Output> Handler<Context, DecodeJson<Output>, Input> for HandleDecodeJson
+#[cgp_impl(new HandleDecodeJson)]
+impl<Context, Input, Output> Handler<DecodeJson<Output>, Input> for Context
 where
     Context: CanRaiseError<serde_json::Error>,
     Input: AsRef<[u8]>,
@@ -26,8 +26,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for HandleEncodeJson
+#[cgp_impl(new HandleEncodeJson)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: CanRaiseError<serde_json::Error>,
     Input: Serialize,

--- a/crates/hypershell-reqwest-components/src/providers/convert.rs
+++ b/crates/hypershell-reqwest-components/src/providers/convert.rs
@@ -6,8 +6,8 @@ use reqwest::Body;
 use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for StreamToBody
+#[cgp_impl(new StreamToBody)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     Input: Send + AsyncRead + 'static,

--- a/crates/hypershell-reqwest-components/src/providers/core_request.rs
+++ b/crates/hypershell-reqwest-components/src/providers/core_request.rs
@@ -8,9 +8,9 @@ use reqwest::{Body, Method, Response, Url};
 use crate::components::{CanUpdateRequestBuilder, HasReqwestClient};
 use crate::dsl::CoreHttpRequest;
 
-#[cgp_new_provider]
+#[cgp_impl(new HandleCoreHttpRequest)]
 impl<Context, MethodArg, UrlArg, Headers, Input>
-    Handler<Context, CoreHttpRequest<MethodArg, UrlArg, Headers>, Input> for HandleCoreHttpRequest
+    Handler<CoreHttpRequest<MethodArg, UrlArg, Headers>, Input> for Context
 where
     Context: HasReqwestClient
         + CanExtractUrlArg<UrlArg, Url = Url>

--- a/crates/hypershell-reqwest-components/src/providers/headers.rs
+++ b/crates/hypershell-reqwest-components/src/providers/headers.rs
@@ -10,8 +10,8 @@ use crate::components::{
     CanUpdateRequestBuilder, RequestBuilderUpdater, RequestBuilderUpdaterComponent,
 };
 
-#[cgp_new_provider]
-impl<Context, Key, Value> RequestBuilderUpdater<Context, Header<Key, Value>> for UpdateRequestHeader
+#[cgp_impl(new UpdateRequestHeader)]
+impl<Context, Key, Value> RequestBuilderUpdater<Header<Key, Value>> for Context
 where
     Context: CanExtractStringArg<Key>
         + CanExtractStringArg<Value>
@@ -36,12 +36,11 @@ where
 
 pub struct UpdateRequestHeaders;
 
-#[cgp_provider]
-impl<Context, Arg, Args> RequestBuilderUpdater<Context, WithHeaders<Cons<Arg, Args>>>
-    for UpdateRequestHeaders
+#[cgp_impl(UpdateRequestHeaders)]
+impl<Context, Arg, Args> RequestBuilderUpdater<WithHeaders<Cons<Arg, Args>>> for Context
 where
     Context: CanUpdateRequestBuilder<Arg>,
-    Self: RequestBuilderUpdater<Context, WithHeaders<Args>>,
+    UpdateRequestHeaders: RequestBuilderUpdater<Context, WithHeaders<Args>>,
 {
     fn update_request_builder(
         context: &Context,
@@ -49,15 +48,18 @@ where
         builder: RequestBuilder,
     ) -> Result<RequestBuilder, Context::Error> {
         let builder = context.update_request_builder(PhantomData, builder)?;
-        let builder =
-            Self::update_request_builder(context, PhantomData::<WithHeaders<Args>>, builder)?;
+        let builder = UpdateRequestHeaders::update_request_builder(
+            context,
+            PhantomData::<WithHeaders<Args>>,
+            builder,
+        )?;
 
         Ok(builder)
     }
 }
 
-#[cgp_provider]
-impl<Context> RequestBuilderUpdater<Context, WithHeaders<Nil>> for UpdateRequestHeaders
+#[cgp_impl(UpdateRequestHeaders)]
+impl<Context> RequestBuilderUpdater<WithHeaders<Nil>> for Context
 where
     Context: HasErrorType,
 {

--- a/crates/hypershell-reqwest-components/src/providers/method_arg.rs
+++ b/crates/hypershell-reqwest-components/src/providers/method_arg.rs
@@ -9,8 +9,8 @@ use reqwest::Method;
 
 pub struct ExtractReqwestMethod;
 
-#[cgp_provider]
-impl<Context> MethodArgExtractor<Context, GetMethod> for ExtractReqwestMethod
+#[cgp_impl(ExtractReqwestMethod)]
+impl<Context> MethodArgExtractor<GetMethod> for Context
 where
     Context: HasHttpMethodType<HttpMethod = Method>,
 {
@@ -19,8 +19,8 @@ where
     }
 }
 
-#[cgp_provider]
-impl<Context> MethodArgExtractor<Context, PostMethod> for ExtractReqwestMethod
+#[cgp_impl(ExtractReqwestMethod)]
+impl<Context> MethodArgExtractor<PostMethod> for Context
 where
     Context: HasHttpMethodType<HttpMethod = Method>,
 {
@@ -29,8 +29,8 @@ where
     }
 }
 
-#[cgp_provider]
-impl<Context> MethodArgExtractor<Context, PutMethod> for ExtractReqwestMethod
+#[cgp_impl(ExtractReqwestMethod)]
+impl<Context> MethodArgExtractor<PutMethod> for Context
 where
     Context: HasHttpMethodType<HttpMethod = Method>,
 {
@@ -39,8 +39,8 @@ where
     }
 }
 
-#[cgp_provider]
-impl<Context> MethodArgExtractor<Context, DeleteMethod> for ExtractReqwestMethod
+#[cgp_impl(ExtractReqwestMethod)]
+impl<Context> MethodArgExtractor<DeleteMethod> for Context
 where
     Context: HasHttpMethodType<HttpMethod = Method>,
 {

--- a/crates/hypershell-reqwest-components/src/providers/simple_request.rs
+++ b/crates/hypershell-reqwest-components/src/providers/simple_request.rs
@@ -12,10 +12,9 @@ pub struct ErrorResponse {
     pub response: Response,
 }
 
-#[cgp_new_provider]
+#[cgp_impl(new HandleSimpleHttpRequest)]
 impl<Context, MethodArg, UrlArg, Headers, Input>
-    Handler<Context, SimpleHttpRequest<MethodArg, UrlArg, Headers>, Input>
-    for HandleSimpleHttpRequest
+    Handler<SimpleHttpRequest<MethodArg, UrlArg, Headers>, Input> for Context
 where
     Context: CanHandle<CoreHttpRequest<MethodArg, UrlArg, Headers>, Input, Output = Response>
         + CanRaiseError<reqwest::Error>

--- a/crates/hypershell-reqwest-components/src/providers/streaming_request.rs
+++ b/crates/hypershell-reqwest-components/src/providers/streaming_request.rs
@@ -10,10 +10,9 @@ use reqwest::Response;
 use crate::dsl::CoreHttpRequest;
 use crate::providers::ErrorResponse;
 
-#[cgp_new_provider]
+#[cgp_impl(new HandleStreamingHttpRequest)]
 impl<Context, MethodArg, UrlArg, Headers, Input>
-    Handler<Context, StreamingHttpRequest<MethodArg, UrlArg, Headers>, Input>
-    for HandleStreamingHttpRequest
+    Handler<StreamingHttpRequest<MethodArg, UrlArg, Headers>, Input> for Context
 where
     Context: CanHandle<CoreHttpRequest<MethodArg, UrlArg, Headers>, Input, Output = Response>
         + CanRaiseError<reqwest::Error>

--- a/crates/hypershell-reqwest-components/src/providers/url_encode.rs
+++ b/crates/hypershell-reqwest-components/src/providers/url_encode.rs
@@ -8,8 +8,8 @@ use hypershell_components::components::{
 use hypershell_components::dsl::UrlEncodeArg;
 use url::form_urlencoded;
 
-#[cgp_new_provider]
-impl<Context, Arg> StringArgExtractor<Context, UrlEncodeArg<Arg>> for UrlEncodeStringArg
+#[cgp_impl(new UrlEncodeStringArg)]
+impl<Context, Arg> StringArgExtractor<UrlEncodeArg<Arg>> for Context
 where
     Context: CanExtractStringArg<Arg>,
 {

--- a/crates/hypershell-tokio-components/src/providers/core_exec.rs
+++ b/crates/hypershell-tokio-components/src/providers/core_exec.rs
@@ -13,9 +13,8 @@ use tokio::process::{Child, Command};
 use crate::components::CanUpdateCommand;
 use crate::dsl::CoreExec;
 
-#[cgp_new_provider]
-impl<Context, CommandPath, Args> Handler<Context, CoreExec<CommandPath, Args>, ()>
-    for HandleCoreExec
+#[cgp_impl(new HandleCoreExec)]
+impl<Context, CommandPath, Args> Handler<CoreExec<CommandPath, Args>, ()> for Context
 where
     Context: HasErrorType
         + CanExtractCommandArg<CommandPath>

--- a/crates/hypershell-tokio-components/src/providers/file.rs
+++ b/crates/hypershell-tokio-components/src/providers/file.rs
@@ -8,8 +8,8 @@ use hypershell_components::dsl::{ReadFile, WriteFile};
 use tokio::fs::File;
 use tokio::io::AsyncRead;
 
-#[cgp_new_provider]
-impl<Context, PathArg> Handler<Context, ReadFile<PathArg>, ()> for HandleReadFile
+#[cgp_impl(new HandleReadFile)]
+impl<Context, PathArg> Handler<ReadFile<PathArg>, ()> for Context
 where
     Context: CanExtractCommandArg<PathArg> + CanRaiseError<std::io::Error>,
     Context::CommandArg: AsRef<Path>,
@@ -31,8 +31,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, PathArg, Input> Handler<Context, WriteFile<PathArg>, Input> for HandleWriteFile
+#[cgp_impl(new HandleWriteFile)]
+impl<Context, PathArg, Input> Handler<WriteFile<PathArg>, Input> for Context
 where
     Context: CanExtractCommandArg<PathArg> + CanRaiseError<std::io::Error>,
     Context::CommandArg: AsRef<Path>,

--- a/crates/hypershell-tokio-components/src/providers/join_args.rs
+++ b/crates/hypershell-tokio-components/src/providers/join_args.rs
@@ -9,18 +9,18 @@ use hypershell_components::dsl::JoinArgs;
 
 pub struct JoinExtractArgs;
 
-#[cgp_provider]
-impl<Context, Arg, Args> CommandArgExtractor<Context, JoinArgs<Cons<Arg, Args>>> for JoinExtractArgs
+#[cgp_impl(JoinExtractArgs)]
+impl<Context, Arg, Args> CommandArgExtractor<JoinArgs<Cons<Arg, Args>>> for Context
 where
     Context: CanExtractCommandArg<Arg> + HasCommandArgType<CommandArg = PathBuf>,
-    Self: CommandArgExtractor<Context, JoinArgs<Args>>,
+    JoinExtractArgs: CommandArgExtractor<Context, JoinArgs<Args>>,
 {
     fn extract_command_arg(
         context: &Context,
         _phantom: PhantomData<JoinArgs<Cons<Arg, Args>>>,
     ) -> PathBuf {
         let arg_a = context.extract_command_arg(PhantomData);
-        let arg_b = Self::extract_command_arg(context, PhantomData::<JoinArgs<Args>>);
+        let arg_b = JoinExtractArgs::extract_command_arg(context, PhantomData::<JoinArgs<Args>>);
 
         if arg_b.as_os_str().is_empty() {
             arg_a
@@ -30,8 +30,8 @@ where
     }
 }
 
-#[cgp_provider]
-impl<Context> CommandArgExtractor<Context, JoinArgs<Nil>> for JoinExtractArgs
+#[cgp_impl(JoinExtractArgs)]
+impl<Context> CommandArgExtractor<JoinArgs<Nil>> for Context
 where
     Context: HasCommandArgType<CommandArg = PathBuf>,
 {

--- a/crates/hypershell-tokio-components/src/providers/line.rs
+++ b/crates/hypershell-tokio-components/src/providers/line.rs
@@ -7,8 +7,8 @@ use hypershell_components::dsl::StreamToLines;
 use tokio::io::AsyncRead;
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
 
-#[cgp_new_provider]
-impl<Context, Input> Handler<Context, StreamToLines, Input> for HandleStreamToLines
+#[cgp_impl(new HandleStreamToLines)]
+impl<Context, Input> Handler<StreamToLines, Input> for Context
 where
     Context: HasErrorType,
     Input: AsyncRead + Unpin + 'static,

--- a/crates/hypershell-tokio-components/src/providers/out.rs
+++ b/crates/hypershell-tokio-components/src/providers/out.rs
@@ -5,8 +5,8 @@ use cgp::prelude::*;
 use hypershell_components::dsl::StreamToStdout;
 use tokio::io::{AsyncRead, copy};
 
-#[cgp_new_provider]
-impl<Context, Input> Handler<Context, StreamToStdout, Input> for HandleStreamToStdout
+#[cgp_impl(new HandleStreamToStdout)]
+impl<Context, Input> Handler<StreamToStdout, Input> for Context
 where
     Context: CanRaiseError<std::io::Error>,
     Input: AsyncRead + Unpin,

--- a/crates/hypershell-tokio-components/src/providers/simple_exec.rs
+++ b/crates/hypershell-tokio-components/src/providers/simple_exec.rs
@@ -14,9 +14,8 @@ pub struct ExecOutputError {
     pub output: Output,
 }
 
-#[cgp_new_provider]
-impl<Context, CommandPath, Args, Input> Handler<Context, SimpleExec<CommandPath, Args>, Input>
-    for HandleSimpleExec
+#[cgp_impl(new HandleSimpleExec)]
+impl<Context, CommandPath, Args, Input> Handler<SimpleExec<CommandPath, Args>, Input> for Context
 where
     Context: CanHandle<CoreExec<CommandPath, Args>, (), Output = Child>
         + for<'a> CanRaiseError<ExecOutputError>

--- a/crates/hypershell-tokio-components/src/providers/stream.rs
+++ b/crates/hypershell-tokio-components/src/providers/stream.rs
@@ -13,8 +13,8 @@ use tokio_util::io::ReaderStream;
 
 use crate::types::{FuturesAsyncReadStream, FuturesStream, TokioAsyncReadStream};
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for HandleTokioAsyncReadToBytes
+#[cgp_impl(new HandleTokioAsyncReadToBytes)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: CanRaiseError<std::io::Error>,
     Input: TokioAsyncRead + Unpin,
@@ -37,8 +37,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for HandleTokioAsyncReadToString
+#[cgp_impl(new HandleTokioAsyncReadToString)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: CanRaiseError<std::io::Error>,
     Input: TokioAsyncRead + Unpin,
@@ -61,8 +61,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for HandleBytesToTokioAsyncRead
+#[cgp_impl(new HandleBytesToTokioAsyncRead)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: CanRaiseError<std::io::Error>,
     Input: AsRef<[u8]> + Unpin,
@@ -78,8 +78,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for HandleBytesToStream
+#[cgp_impl(new HandleBytesToStream)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: CanRaiseError<std::io::Error>,
     Input: AsRef<[u8]> + Unpin,
@@ -95,8 +95,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for FuturesToTokioAsyncRead
+#[cgp_impl(new FuturesToTokioAsyncRead)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     Input: FuturesAsyncRead + Unpin,
@@ -112,8 +112,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for TokioToFuturesAsyncRead
+#[cgp_impl(new TokioToFuturesAsyncRead)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     Input: TokioAsyncRead + Unpin,
@@ -129,8 +129,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for WrapTokioAsyncRead
+#[cgp_impl(new WrapTokioAsyncRead)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     Input: TokioAsyncRead + Unpin,
@@ -146,8 +146,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for WrapFuturesAsyncRead
+#[cgp_impl(new WrapFuturesAsyncRead)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     Input: FuturesAsyncRead + Unpin,
@@ -163,8 +163,8 @@ where
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Code, Input> Handler<Context, Code, Input> for AsyncReadToStream
+#[cgp_impl(new AsyncReadToStream)]
+impl<Context, Code, Input> Handler<Code, Input> for Context
 where
     Context: HasErrorType,
     Input: TokioAsyncRead + Unpin,

--- a/crates/hypershell-tokio-components/src/providers/streaming_exec.rs
+++ b/crates/hypershell-tokio-components/src/providers/streaming_exec.rs
@@ -10,9 +10,8 @@ use tokio_util::either::Either;
 
 use crate::dsl::CoreExec;
 
-#[cgp_new_provider]
-impl<Context, CommandPath, Args, Input> Handler<Context, StreamingExec<CommandPath, Args>, Input>
-    for HandleStreamingExec
+#[cgp_impl(new HandleStreamingExec)]
+impl<Context, CommandPath, Args, Input> Handler<StreamingExec<CommandPath, Args>, Input> for Context
 where
     Context:
         CanHandle<CoreExec<CommandPath, Args>, (), Output = Child> + CanRaiseError<std::io::Error>,

--- a/crates/hypershell-tokio-components/src/providers/update_command.rs
+++ b/crates/hypershell-tokio-components/src/providers/update_command.rs
@@ -10,8 +10,8 @@ use crate::components::{CommandUpdater, CommandUpdaterComponent};
 
 pub struct ExtractArgs;
 
-#[cgp_provider]
-impl<Context, Arg, Args> CommandUpdater<Context, WithArgs<Cons<Arg, Args>>> for ExtractArgs
+#[cgp_impl(ExtractArgs)]
+impl<Context, Arg, Args> CommandUpdater<WithArgs<Cons<Arg, Args>>> for Context
 where
     Context: CanExtractCommandArg<Arg>,
     Context::CommandArg: AsRef<OsStr> + Send,
@@ -29,8 +29,8 @@ where
     }
 }
 
-#[cgp_provider]
-impl<Context> CommandUpdater<Context, WithArgs<Nil>> for ExtractArgs {
+#[cgp_impl(ExtractArgs)]
+impl<Context> CommandUpdater<WithArgs<Nil>> for Context {
     fn update_command(
         _context: &Context,
         _phantom: PhantomData<WithArgs<Nil>>,
@@ -39,8 +39,8 @@ impl<Context> CommandUpdater<Context, WithArgs<Nil>> for ExtractArgs {
     }
 }
 
-#[cgp_new_provider]
-impl<Context, Tag> CommandUpdater<Context, FieldArgs<Tag>> for ExtractFieldArgs
+#[cgp_impl(new ExtractFieldArgs)]
+impl<Context, Tag> CommandUpdater<FieldArgs<Tag>> for Context
 where
     Context: HasField<Tag>,
     for<'a> &'a Context::Value: IntoIterator<Item: AsRef<OsStr>>,

--- a/crates/hypershell-tungstenite-components/src/providers/websocket.rs
+++ b/crates/hypershell-tungstenite-components/src/providers/websocket.rs
@@ -14,9 +14,8 @@ use tokio_tungstenite::{connect_async, tungstenite};
 use tokio_util::bytes::Bytes;
 use tokio_util::io::ReaderStream;
 
-#[cgp_new_provider]
-impl<Context, UrlArg, Headers, Input> Handler<Context, WebSocket<UrlArg, Headers>, Input>
-    for HandleWebsocket
+#[cgp_impl(new HandleWebsocket)]
+impl<Context, UrlArg, Headers, Input> Handler<WebSocket<UrlArg, Headers>, Input> for Context
 where
     Context: CanExtractStringArg<UrlArg> + CanRaiseError<tungstenite::Error>,
     Input: Send + AsyncRead + Unpin + 'static,

--- a/crates/hypershell/src/contexts/cli.rs
+++ b/crates/hypershell/src/contexts/cli.rs
@@ -2,5 +2,5 @@ use cgp::prelude::*;
 
 use crate::presets::HypershellPreset;
 
-#[cgp_context(HypershellCliComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 pub struct HypershellCli;

--- a/crates/hypershell/src/contexts/http.rs
+++ b/crates/hypershell/src/contexts/http.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 
 use crate::presets::HypershellPreset;
 
-#[cgp_context(HypershellHttpComponents: HypershellPreset)]
+#[cgp_inherit(HypershellPreset)]
 #[derive(HasField)]
 pub struct HypershellHttp {
     pub http_client: Client,


### PR DESCRIPTION
# Summary

This PR incorporate changes from https://github.com/contextgeneric/cgp/pull/174, https://github.com/contextgeneric/cgp/pull/175, and https://github.com/contextgeneric/cgp/pull/176 to simplify the implementation of CGP providers and CGP contexts.